### PR TITLE
Pass min_topic_size to BERTopic

### DIFF
--- a/src/langviz/core/layout/corpus.py
+++ b/src/langviz/core/layout/corpus.py
@@ -129,6 +129,8 @@ def corpus_topics(corpus: Corpus) -> dcc.Graph:
     """
     all_text_documents = [document.doc.text for document in corpus.documents]
 
+    min_topic_size = min(10, len(all_text_documents))
+
     representation_model = KeyBERTInspired()
     ctfidf_model = ClassTfidfTransformer(reduce_frequent_words=True)
 
@@ -140,6 +142,7 @@ def corpus_topics(corpus: Corpus) -> dcc.Graph:
         representation_model=representation_model,
         embedding_model=sentence_model,
         calculate_probabilities=False,
+        min_topic_size=min_topic_size
     )
 
     topic_model.fit(documents=all_text_documents, embeddings=embeddings)  # type:ignore


### PR DESCRIPTION
This sets the minimum topic size to the minimum of 10 (BERTopic's default) and the number of documents, which prevents fit() from throwing an error when the number of documents is below 10.